### PR TITLE
Switch to more up to date docker image

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -18,9 +18,9 @@
 #  Rust-sgx-sdk installed
 #  IPFS installed
 ARG VERSION_UBUNTU=2004
-ARG VERSION_RUST_SGX_SDK=1.1.4
+ARG VERSION_RUST_SGX_SDK=1.1.6
 
-FROM baiduxlab/sgx-rust:${VERSION_UBUNTU}-${VERSION_RUST_SGX_SDK}
+FROM niederb/sgx-rust:${VERSION_UBUNTU}-${VERSION_RUST_SGX_SDK}
 LABEL maintainer="zoltan@integritee.network"
 LABEL description="Generic Dockerfile for Intel SGX development and CI machines"
 ARG VERSION_IPFS=0.4.21


### PR DESCRIPTION
Switch to the docker image I build.
- Based on 715ee87e5ff98f3642f1d09b4c30343c8bcc5ee4
- Built on Ubuntu 22.04, but our worker CI passed fine. See https://github.com/integritee-network/worker/actions/runs/3575423203